### PR TITLE
Enrich fp_harness with §11.1 metrics + golden-snapshot drift gate

### DIFF
--- a/crates/nav-core/Cargo.toml
+++ b/crates/nav-core/Cargo.toml
@@ -13,3 +13,7 @@ thiserror = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 xattr = "1"
+
+[dev-dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/nav-core/tests/fp_harness.rs
+++ b/crates/nav-core/tests/fp_harness.rs
@@ -1,12 +1,18 @@
 //! False-positive evaluation harness (§11.1). Known-benign and
 //! synthetic-suspicious fixtures under `fixtures/`, checked against the
 //! engine's output. Grow it by adding files or `.app` dirs under
-//! `fixtures/benign/` or `fixtures/suspicious/` — no code changes.
+//! `fixtures/benign/` or `fixtures/suspicious/` — no code changes, but a
+//! new or changed fixture requires regenerating the golden snapshot below
+//! (`UPDATE_GOLDEN=1 cargo test -p nav-core --test fp_harness`) and
+//! committing the result.
 //!
 //! Guards against: a rule change pushing a benign sample over the alert
-//! threshold, or making scoring nondeterministic.
+//! threshold, making scoring nondeterministic, or (via the golden snapshot)
+//! silently changing a fixture's score, recommendation, or fired rule ids.
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 use nav_core::{scan_target, Recommendation, TargetScan};
 
@@ -49,6 +55,26 @@ fn list_fixtures(sub: &str) -> Vec<PathBuf> {
 fn scan(path: &Path) -> TargetScan {
     scan_target(path, false)
         .unwrap_or_else(|e| panic!("failed to scan fixture {}: {e}", path.display()))
+}
+
+/// Sorted, deduplicated union of rule ids fired anywhere in a target scan —
+/// for a single-file target this is just that file's signals; for a
+/// directory/`.app` target it's the union across every scanned member.
+fn fired_rule_ids(scan: &TargetScan) -> Vec<String> {
+    let mut ids: Vec<String> = scan
+        .results
+        .iter()
+        .flat_map(|r| r.signals.iter().map(|s| s.id.clone()))
+        .collect();
+    ids.sort();
+    ids.dedup();
+    ids
+}
+
+/// `sub/filename` — the golden file's key and the metrics report's label for
+/// a fixture.
+fn fixture_key(sub: &str, path: &Path) -> String {
+    format!("{sub}/{}", path.file_name().unwrap().to_string_lossy())
 }
 
 #[test]
@@ -116,4 +142,190 @@ fn scoring_is_deterministic() {
             );
         }
     }
+}
+
+/// Per-fixture and aggregate scan metrics, reported for visibility (§11.1:
+/// "track more than pass/fail: final score, matched rule IDs, runtime,
+/// memory, files traversed"). Nothing here is asserted — runtime is
+/// environment-dependent and would flake CI; the golden-snapshot test below
+/// is the actual pass/fail gate on score/recommendation/rule_ids. Run with
+/// `cargo test -p nav-core --test fp_harness report_fixture_metrics -- --nocapture`
+/// to see the table.
+///
+/// TODO(§11.1): peak memory isn't tracked. A global-allocator hook would
+/// double as a per-fixture counter, but cargo's test harness runs every
+/// `#[test]` fn as a thread in one shared process with one allocator
+/// instance, so counts would mix in whatever else is allocating
+/// concurrently — a misattributed number is worse than an honestly absent
+/// one, so this is deferred rather than faked.
+#[test]
+fn report_fixture_metrics() {
+    let mut total_files = 0usize;
+    let mut total_runtime = Duration::ZERO;
+
+    println!();
+    println!("{:-<95}", "");
+    println!(
+        "{:<40} {:>7} {:>7} {:>10}  rule_ids",
+        "fixture", "score", "files", "runtime"
+    );
+    println!("{:-<95}", "");
+
+    for sub in ["benign", "suspicious"] {
+        for path in list_fixtures(sub) {
+            let start = Instant::now();
+            let result = scan(&path);
+            let elapsed = start.elapsed();
+
+            let files_traversed = result.results.len() + result.skipped.len();
+            let score = result.worst().map(|r| r.score).unwrap_or(0);
+            let rule_ids = fired_rule_ids(&result);
+
+            total_files += files_traversed;
+            total_runtime += elapsed;
+
+            println!(
+                "{:<40} {:>7} {:>7} {:>8.2}ms  {}",
+                fixture_key(sub, &path),
+                score,
+                files_traversed,
+                elapsed.as_secs_f64() * 1000.0,
+                if rule_ids.is_empty() {
+                    "-".to_string()
+                } else {
+                    rule_ids.join(",")
+                },
+            );
+        }
+    }
+
+    println!("{:-<95}", "");
+    println!(
+        "total: files_traversed={total_files} runtime={:.2}ms memory=not yet tracked (see TODO above)",
+        total_runtime.as_secs_f64() * 1000.0
+    );
+    println!();
+}
+
+/// The deterministic, platform-stable fields snapshotted per fixture for the
+/// golden-file regression gate: everything the engine promises is stable
+/// across a run on a given platform, and nothing that varies with wall-clock
+/// time or engine version (see `ScanResult::evaluated_at`/`engine_version`,
+/// deliberately excluded).
+///
+/// For a directory/`.app` target this is the target-level verdict — the
+/// worst scanned member's score/recommendation, via
+/// `TargetScan::recommendation`/`worst` — plus the sorted union of rule ids
+/// fired across every scanned member. For a single-file target this
+/// collapses to that one file's own score/recommendation/signals.
+#[cfg(target_os = "macos")]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+struct FixtureSnapshot {
+    score: i32,
+    recommendation: Recommendation,
+    rule_ids: Vec<String>,
+}
+
+#[cfg(target_os = "macos")]
+impl FixtureSnapshot {
+    fn of(scan: &TargetScan) -> Self {
+        Self {
+            score: scan.worst().map(|r| r.score).unwrap_or(0),
+            recommendation: scan.recommendation(),
+            rule_ids: fired_rule_ids(scan),
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn golden_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("golden")
+        .join("fp_snapshot.json")
+}
+
+/// Golden-snapshot regression gate (§11.1). Compares every fixture's
+/// [`FixtureSnapshot`] against a committed golden file and fails with a
+/// per-fixture expected-vs-actual diff on any mismatch — this is what
+/// catches a rule change silently altering a known-benign sample's score,
+/// or introducing an unexpectedly high-severity signal.
+///
+/// Gated to macOS: off-macOS the codesign/spctl rules return
+/// `RuleOutcome::NotApplicable` (scanner.md §5.2), so scans come back
+/// `Partial` rather than `Complete`, and Mach-O/`.app`/`.pkg` fixtures would
+/// snapshot differently than on the real target platform (roadmap.md §12
+/// treats a golden-file format as Phase 0a scaffolding, on the assumption
+/// it's evaluated where NAV actually runs). The three tests above stay
+/// cross-platform since they don't depend on exact scores.
+///
+/// To regenerate after an intentional rule change, review the resulting
+/// `git diff` before committing:
+/// ```sh
+/// UPDATE_GOLDEN=1 cargo test -p nav-core --test fp_harness
+/// ```
+#[cfg(target_os = "macos")]
+#[test]
+fn golden_snapshot_matches_known_fixtures() {
+    let mut actual: BTreeMap<String, FixtureSnapshot> = BTreeMap::new();
+    for sub in ["benign", "suspicious"] {
+        for path in list_fixtures(sub) {
+            let key = fixture_key(sub, &path);
+            actual.insert(key, FixtureSnapshot::of(&scan(&path)));
+        }
+    }
+
+    let path = golden_path();
+
+    if std::env::var("UPDATE_GOLDEN").as_deref() == Ok("1") {
+        let json = serde_json::to_string_pretty(&actual).unwrap() + "\n";
+        std::fs::write(&path, json)
+            .unwrap_or_else(|e| panic!("failed to write golden file {}: {e}", path.display()));
+        println!("wrote golden file: {}", path.display());
+        return;
+    }
+
+    let raw = std::fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!(
+            "failed to read golden file {}: {e}\nGenerate it with: \
+             UPDATE_GOLDEN=1 cargo test -p nav-core --test fp_harness",
+            path.display()
+        )
+    });
+    let expected: BTreeMap<String, FixtureSnapshot> = serde_json::from_str(&raw)
+        .unwrap_or_else(|e| panic!("failed to parse golden file {}: {e}", path.display()));
+
+    let mut diffs = Vec::new();
+    for (key, actual_snap) in &actual {
+        match expected.get(key) {
+            Some(expected_snap) if expected_snap == actual_snap => {}
+            Some(expected_snap) => diffs.push(format!(
+                "{key}:\n  expected: score={} recommendation={:?} rule_ids={:?}\n  actual:   score={} recommendation={:?} rule_ids={:?}",
+                expected_snap.score,
+                expected_snap.recommendation,
+                expected_snap.rule_ids,
+                actual_snap.score,
+                actual_snap.recommendation,
+                actual_snap.rule_ids,
+            )),
+            None => diffs.push(format!("{key}: new fixture, missing from golden file")),
+        }
+    }
+    for key in expected.keys() {
+        if !actual.contains_key(key) {
+            diffs.push(format!(
+                "{key}: present in golden file but no longer scanned (fixture renamed or removed?)"
+            ));
+        }
+    }
+
+    assert!(
+        diffs.is_empty(),
+        "golden snapshot mismatch — a rule change altered a known fixture's score, \
+         recommendation, or fired rule ids, or a fixture was added/renamed/removed without \
+         regenerating the golden file. If this is intended, regenerate with \
+         `UPDATE_GOLDEN=1 cargo test -p nav-core --test fp_harness`, review the diff, and \
+         commit the result.\n\n{}",
+        diffs.join("\n\n")
+    );
 }

--- a/crates/nav-core/tests/fp_harness.rs
+++ b/crates/nav-core/tests/fp_harness.rs
@@ -10,9 +10,13 @@
 //! threshold, making scoring nondeterministic, or (via the golden snapshot)
 //! silently changing a fixture's score, recommendation, or fired rule ids.
 
-use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
+
+// Only the macOS-gated golden-snapshot test uses BTreeMap; an unconditional
+// import is dead code off-macOS and trips clippy's `-D warnings`.
+#[cfg(target_os = "macos")]
+use std::collections::BTreeMap;
 
 use nav_core::{scan_target, Recommendation, TargetScan};
 

--- a/crates/nav-core/tests/golden/fp_snapshot.json
+++ b/crates/nav-core/tests/golden/fp_snapshot.json
@@ -1,0 +1,207 @@
+{
+  "benign/CHANGELOG.md": {
+    "score": 0,
+    "recommendation": "no-action",
+    "rule_ids": []
+  },
+  "benign/ElectronDemo.app": {
+    "score": 0,
+    "recommendation": "no-action",
+    "rule_ids": []
+  },
+  "benign/NamedDiff.app": {
+    "score": 0,
+    "recommendation": "no-action",
+    "rule_ids": []
+  },
+  "benign/SampleHelper.app": {
+    "score": 8,
+    "recommendation": "no-action",
+    "rule_ids": [
+      "launchd-persistence-plist"
+    ]
+  },
+  "benign/admin_reset_prefs.sh": {
+    "score": 0,
+    "recommendation": "no-action",
+    "rule_ids": []
+  },
+  "benign/admin_toggle_wifi.sh": {
+    "score": 0,
+    "recommendation": "no-action",
+    "rule_ids": []
+  },
+  "benign/app_settings.json": {
+    "score": 0,
+    "recommendation": "no-action",
+    "rule_ids": []
+  },
+  "benign/build.sh": {
+    "score": 0,
+    "recommendation": "no-action",
+    "rule_ids": []
+  },
+  "benign/com.example.devtool.plist": {
+    "score": 8,
+    "recommendation": "no-action",
+    "rule_ids": [
+      "launchd-persistence-plist"
+    ]
+  },
+  "benign/com.example.helper.plist": {
+    "score": 0,
+    "recommendation": "no-action",
+    "rule_ids": []
+  },
+  "benign/com.example.menubar.plist": {
+    "score": 0,
+    "recommendation": "no-action",
+    "rule_ids": []
+  },
+  "benign/compressed_archive.tar.gz": {
+    "score": 0,
+    "recommendation": "no-action",
+    "rule_ids": []
+  },
+  "benign/csv_report.py": {
+    "score": 0,
+    "recommendation": "no-action",
+    "rule_ids": []
+  },
+  "benign/formula.rb": {
+    "score": 3,
+    "recommendation": "no-action",
+    "rule_ids": [
+      "suspicious-strings"
+    ]
+  },
+  "benign/formula_cmake.rb": {
+    "score": 0,
+    "recommendation": "no-action",
+    "rule_ids": []
+  },
+  "benign/formula_git_clone.rb": {
+    "score": 0,
+    "recommendation": "no-action",
+    "rule_ids": []
+  },
+  "benign/installer_nested.pkg": {
+    "score": 6,
+    "recommendation": "no-action",
+    "rule_ids": [
+      "unsigned-installer-package"
+    ]
+  },
+  "benign/installer_no_scripts.pkg": {
+    "score": 6,
+    "recommendation": "no-action",
+    "rule_ids": [
+      "unsigned-installer-package"
+    ]
+  },
+  "benign/installer_ordinary.pkg": {
+    "score": 6,
+    "recommendation": "no-action",
+    "rule_ids": [
+      "unsigned-installer-package"
+    ]
+  },
+  "benign/macho_like_but_incomplete": {
+    "score": 4,
+    "recommendation": "no-action",
+    "rule_ids": [
+      "unsigned-binary"
+    ]
+  },
+  "benign/readme.txt": {
+    "score": 0,
+    "recommendation": "no-action",
+    "rule_ids": []
+  },
+  "benign/tiny_hello_arm64": {
+    "score": 0,
+    "recommendation": "no-action",
+    "rule_ids": []
+  },
+  "suspicious/com.apple.softwareupdate.plist": {
+    "score": 36,
+    "recommendation": "notify",
+    "rule_ids": [
+      "launchd-persistence-plist",
+      "suspicious-strings"
+    ]
+  },
+  "suspicious/dropper.sh": {
+    "score": 23,
+    "recommendation": "notify",
+    "rule_ids": [
+      "suspicious-strings"
+    ]
+  },
+  "suspicious/dropper_base64_exec.sh": {
+    "score": 13,
+    "recommendation": "no-action",
+    "rule_ids": [
+      "suspicious-strings"
+    ]
+  },
+  "suspicious/dropper_curl_pipe_bash.sh": {
+    "score": 13,
+    "recommendation": "no-action",
+    "rule_ids": [
+      "suspicious-strings"
+    ]
+  },
+  "suspicious/dropper_osascript_fetch.sh": {
+    "score": 9,
+    "recommendation": "no-action",
+    "rule_ids": [
+      "suspicious-strings"
+    ]
+  },
+  "suspicious/installer_applescript_preinstall.pkg": {
+    "score": 15,
+    "recommendation": "notify",
+    "rule_ids": [
+      "installer-script-suspicious",
+      "unsigned-installer-package"
+    ]
+  },
+  "suspicious/installer_curl_pipe_preinstall.pkg": {
+    "score": 15,
+    "recommendation": "notify",
+    "rule_ids": [
+      "installer-script-suspicious",
+      "unsigned-installer-package"
+    ]
+  },
+  "suspicious/packed_payload.sh": {
+    "score": 31,
+    "recommendation": "notify",
+    "rule_ids": [
+      "high-entropy-content",
+      "suspicious-strings"
+    ]
+  },
+  "suspicious/packed_payload_variant.py": {
+    "score": 15,
+    "recommendation": "notify",
+    "rule_ids": [
+      "high-entropy-content"
+    ]
+  },
+  "suspicious/persistence_beacon.plist": {
+    "score": 26,
+    "recommendation": "notify",
+    "rule_ids": [
+      "launchd-persistence-plist"
+    ]
+  },
+  "suspicious/tcc_keychain_exfil.sh": {
+    "score": 21,
+    "recommendation": "notify",
+    "rule_ids": [
+      "suspicious-strings"
+    ]
+  }
+}


### PR DESCRIPTION
## What

Implements the §11.1 requirement that the FP harness track more than pass/fail — final score, matched rule IDs, runtime, files traversed — and fail CI on unexpected verdict drift, not just on a benign sample crossing the alert threshold.

- **Golden-snapshot drift gate** (`golden_snapshot_matches_known_fixtures`, macOS-gated): a committed `tests/golden/fp_snapshot.json` records each fixture's deterministic verdict (score, recommendation, sorted rule IDs). The test scans every fixture and fails with a per-fixture expected-vs-actual diff on any drift — catching "unexpected high-severity signal" / score changes, plus fixtures added/removed vs. the golden. Gated to macOS because that's where the codesign/spctl rules run; off-macOS those return `NotApplicable` and Mach-O fixtures would snapshot differently.
- **Regeneration path**: `UPDATE_GOLDEN=1 cargo test -p nav-core --test fp_harness`, documented in the harness so changing/adding fixtures has an obvious update flow.
- **Metric reporting** (`report_fixture_metrics`, cross-platform): prints per-fixture + aggregate score, rule IDs, files traversed, wall-clock runtime. Nothing asserted (runtime is environment-dependent — asserting it would flake CI).
- **Memory: honestly deferred**, not faked — a process-wide counting allocator would misattribute across `cargo test`'s shared-process threads, so it's a `TODO(§11.1)` rather than a bogus number.

## Testing

- `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` all green (fp_harness now 5 tests).
- Verified the gate actually fails: corrupting one golden score produced a clear diff naming the fixture; regenerating restored a clean pass; determinism confirmed across repeated runs.
- CI already has a `macos-latest` job, so the macOS-gated gate runs in CI — no CI changes.

## Scope

Test-harness + golden data only; no rule/engine code changed. The golden also pins previously-undocumented macOS behavior (e.g. `macho_like_but_incomplete` → `unsigned-binary` score 4; two benign fixtures trip `launchd-persistence-plist` at 8 — all safely `no-action`).